### PR TITLE
fix: move window.chatsuboApp export to after initialization

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,9 @@ async function initialize() {
     // Initialize app
     await app.initialize();
 
+    // Export for console debugging (after initialization)
+    window.chatsuboApp = app;
+
     // Enable join button
     const joinButton = getElement('join-button');
     if (joinButton) joinButton.disabled = false;
@@ -454,6 +457,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-// Export for console debugging
-window.chatsuboApp = app;
+// Export moveToZone for console debugging
 window.moveToZone = moveToZone;


### PR DESCRIPTION
## Summary
- Fixed bug where `window.chatsuboApp` was null because it was set before initialization
- Moved export to after `app.initialize()` completes
- Now console debugging works correctly: `window.chatsuboApp.aiModule` is accessible

## Test plan
- [ ] Open browser console after page loads
- [ ] Run `window.chatsuboApp` - should return ChatsuboApp instance (not null)
- [ ] Run `window.chatsuboApp.aiModule` - should return AI module

🤖 Generated with [Claude Code](https://claude.com/claude-code)